### PR TITLE
Move back to V1 attributes

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,19 +13,19 @@ Required attributes of script tag:
 * **data-dm-dealership-id**: Unique Dealership ID.
 * **data-dm-vehicle-vin**: Full vin number of vehicle to display pictures for.
 
-By default, the media layer will be placed in the same element as the script tag. However, the media layer can be displayed ina different area, with the folliwing placement attributes. Note that they are mutually exclusive, and not to be used in conjunction with one another. Only ONE of the following optional attributes should be used per script tag:
+By default, the media layer will be placed in the same element as the script tag. However, the media layer can be displayed in a different area, with the folliwing placement attributes:
 * **data-dm-replace-element-id**: One element id to replace with the media layer
 * **data-dm-insert-before-element-id**: One element id where the media layer will insert before
 * **data-dm-insert-after-element-id**: One element id where the media layer will insert after
-* **data-dm-insert-before-element-attribute**: One element attribute to find and insert the media layer before, for example: data-widget-id
-* **data-dm-insert-before-element-attribute-value**: One element attribute and value pair that the media layer will insert before. _The attribute and value should be specified and separated by a "&#124;" pipe character_. For example: _data-dm-insert-before-element-attribute-value="data-widget-id&#124;inventory-detail1"_ would find the first tag with data-widget-id="inventory-detail1" and insert the media layer before it
-* **data-dm-insert-after-element-attribute**: One element attribute to find and insert the media layer after, for example: data-widget-id
-* **data-dm-insert-after-element-attribute-value**: One element attribute and value pair that the media layer will insert after. _The attribute and value should be specified and separated by a "&#124;" pipe character_. For example: _data-dm-insert-after-element-attribute-value="data-widget-id&#124;inventory-detail1"_ would find the first tag with data-widget-id="inventory-detail1" and insert the media layer after it
+* **data-dm-insert-before-element-attribute**: One element attribute to find and insert the media layer before, for example: data-widget-id  **[optional]**.
+* **data-dm-insert-before-element-attribute-value**: One element attribute value that matches data-dm-insert-before-element-attribute and _must be used with_ data-dm-insert-before-element-attribute.  For example the following value of: inventory-detail1 used with the above example of "data-widget-id" would find all html tags with data-widget-id="inventory-detail1" and insert the media layer above it.      **[optional]**.
+* **data-dm-insert-after-element-attribute**: One element attribute to find and insert the media layer after, for example: data-widget-id  **[optional]**.
+* **data-dm-insert-after-element-attribute-value**: One element attribute value that matches data-dm-insert-after-element-attribute and _must be used with_ data-dm-insert-after-element-attribute.  For example the following value of: inventory-detail1 used with the above example of "data-widget-id" would find all html tags with data-widget-id="inventory-detail1" and insert the media layer after it. **[optional]**.
 
 Other optional attributes:
-* **data-dm-hide-element-ids**: One or many element ids separated by a " " space character that will be hidden when the media layer and the corresponding vehicle pictures are loaded
+* **data-dm-element-ids-to-hide**: One or many element ids separated by a " " space character that will be hidden when the media layer and the corresponding vehicle pictures are loaded
 * **data-dm-force-hd**: In this mode, the standard media layer will not be displayed at all, and the HD media layer will automatically load. _Note: the user will be unable to exit the HD media layer other than by closing the page. Only use this attribute on pages in which you intend to show the media layer exclusively_
-* **data-dm-manual-hd**: In this mode, the standard media layer will not be displayed at all. The HD media layer can be manually triggered by calling the function `triggerHdMediaLayer()`. So, for instance, you may add a button to the page with an onclick event that triggers the HD media layer, like so: `<button onclick="triggerHdMediaLayer()">Click Me</button>`. Unlike with data-dm-force-hd, the user will be able to exit the HD media layer.
+* **data-dm-manual-hd**: In this mode, if this attribute is set to "yes", the standard media layer will not be displayed at all. The HD media layer can be manually triggered by calling the function `triggerHdMediaLayer()`. So, for instance, you may add a button to the page with an onclick event that triggers the HD media layer, like so: `<button onclick="triggerHdMediaLayer()">Click Me</button>`. Unlike with data-dm-force-hd, the user will be able to exit the HD media layer. Alternately, if this attribute is set to "button", a pre-styled "Launch HD Media Layer" button will appear in place of the media layer.
 
 ### The media layer will remain invisible until pictures have been taken for the vehicle using the dealermade photo studio, also the element ids listed in data-dm-element-ids-to-hide will not be hidden unless the media layer has loaded with pictures.
 
@@ -36,7 +36,7 @@ Other optional attributes:
 data-dm-dealership-id="team-of-navasota" 
 data-dm-vehicle-vin="1FTEW1EF4FFA24461"
 data-dm-replace-element-id="vpActualContent"
-data-dm-hide-element-ids="dtlExpand dtlExpand2"></script>
+data-dm-element-ids-to-hide="dtlExpand dtlExpand2"></script>
 ```
 
 


### PR DESCRIPTION
We've changed the V2 attributes to be identical to those of V1, so the documentation needs to be changed in order to reflect that.